### PR TITLE
Feat/UI catalog

### DIFF
--- a/.github/workflows/publish_web.yml
+++ b/.github/workflows/publish_web.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: stable
+      - run: flutter pub get
+      - uses: bluefireteam/flutter-gh-pages@v7
+        with:
+          baseHref: /cleanlet-app/
+          customArgs: "-t lib/ui_catalog.dart"

--- a/lib/ui_catalog.dart
+++ b/lib/ui_catalog.dart
@@ -1,0 +1,65 @@
+import 'package:cleanlet/views/login.dart';
+import 'package:cleanlet/views/test.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const CleanletUiCatalog());
+}
+
+class CleanletUiCatalog extends StatelessWidget {
+  const CleanletUiCatalog({super.key});
+  static const _views = [
+    {
+      'route': '/test',
+      'title': 'Test'
+    },
+    {
+      'route': '/login',
+      'title': 'Login'
+    }
+  ];
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Cleanlet UI Catalog',
+      routes: {
+        '/test': (context) => const TestPage(),
+        '/login': (context) => const LoginPage(),
+      },
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Cleanlet UI Catalog'),
+        ),
+        body: Column(
+          children: [
+            Expanded(
+              child: ListView.separated(
+                itemCount: _views.length,
+                itemBuilder: (BuildContext context, int index) {
+                  final title = _views[index]['title'];
+                  final subtitle = _views[index]['subtitle'];
+                  final route = _views[index]['route'];
+
+                  return Ink(
+                    color: Theme.of(context).cardColor,
+                    child: ListTile(
+                      title: Text(title!),
+                      subtitle:
+                      subtitle != null ? Text(subtitle.toString()) : null,
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: () {
+                        Navigator.pushNamed(context, route!);
+                      },
+                    ),
+                  );
+                },
+                separatorBuilder: (BuildContext context, int index) =>
+                const Divider(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui_catalog.dart
+++ b/lib/ui_catalog.dart
@@ -11,7 +11,8 @@ class CleanletUiCatalog extends StatelessWidget {
   static const _views = [
     {
       'route': '/test',
-      'title': 'Test'
+      'title': 'Test',
+      'subtitle': 'This is a subtitle test',
     },
     {
       'route': '/login',
@@ -41,7 +42,6 @@ class CleanletUiCatalog extends StatelessWidget {
                   final route = _views[index]['route'];
 
                   return Ink(
-                    color: Theme.of(context).cardColor,
                     child: ListTile(
                       title: Text(title!),
                       subtitle:

--- a/lib/views/login.dart
+++ b/lib/views/login.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class LoginPage extends StatelessWidget {
+  const LoginPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return  Scaffold(
+      appBar: AppBar(
+        title: const Text('Login Page'),
+      ),
+      body: const Center(
+        child: Text('This is a test login widget'),
+      ),
+    );
+  }
+}

--- a/lib/views/test.dart
+++ b/lib/views/test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class TestPage extends StatelessWidget {
+  const TestPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return  Scaffold(
+      appBar: AppBar(
+        title: const Text('Test Page'),
+      ),
+      body: const Center(
+        child: Text('This is a test widget'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Build Basic UI Catalog functionality as a different entry point to the app. This currently has two placeholder views.

[This is then published to flutter for web here](https://cleanlet.github.io/cleanlet-app/#/)

Currently, I'm just using basic GH Pages branch deployments. Eventually, we may want to do something more complex using GHA to build the main app at `/` and then the UI Catalog at `/ui-catalog/`. 